### PR TITLE
Add parquet-first data download scripts and production training/backtest pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
 # NekoAITarderV1
+
+AI-powered trading bot for forex and crypto with model training, backtesting, and Telegram/MT5 integration.
+
+## Data preparation (Parquet-first)
+
+### 1) Download FX Dukascopy data to parquet
+
+```bash
+python scripts/download_fx_dukascopy_parquet.py \
+  --pairs EURUSD USDJPY GBPUSD USDCHF AUDUSD \
+  --start-year 2016 --end-year 2025 \
+  --output-dir data/raw/fx
+```
+
+### 2) Download crypto OHLCV to parquet
+
+```bash
+python scripts/download_crypto_parquet.py \
+  --symbols BTCUSDT ETHUSDT BNBUSDT SOLUSDT ADAUSDT DOTUSDT XRPUSDT \
+  --timeframe 1m --period 60d \
+  --output-dir data/raw/crypto
+```
+
+## Production training & backtesting (using parquet data)
+
+- `scripts/production_train.py`
+  - Uses local parquet files first (`data/raw/fx`, `data/raw/crypto`).
+  - In default mode (`--data-mode parquet-only`), training **fails fast** if parquet is missing/low quality.
+  - Runs walk-forward CV, model selection, threshold search, and writes bundle metadata.
+
+- `scripts/production_backtest.py`
+  - Uses the same parquet-first data path.
+  - Uses saved training threshold by default.
+  - Runs cost-aware strict OOS simulation and writes JSON report.
+
+### Example usage
+
+```bash
+python scripts/production_train.py --timeframe 1m --data-mode parquet-only --limit 10000
+python scripts/production_backtest.py --bundle models/production/best_production_bundle.joblib --timeframe 1m --data-mode parquet-only
+```

--- a/scripts/download_crypto_parquet.py
+++ b/scripts/download_crypto_parquet.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Download crypto OHLCV and save parquet files for training/backtesting."""
+
+import argparse
+from pathlib import Path
+import pandas as pd
+import yfinance as yf
+
+DEFAULT_SYMBOLS = ["BTCUSDT", "ETHUSDT", "BNBUSDT", "SOLUSDT", "ADAUSDT", "DOTUSDT", "XRPUSDT"]
+YF_MAP = {
+    "BTCUSDT": "BTC-USD",
+    "ETHUSDT": "ETH-USD",
+    "BNBUSDT": "BNB-USD",
+    "SOLUSDT": "SOL-USD",
+    "ADAUSDT": "ADA-USD",
+    "DOTUSDT": "DOT-USD",
+    "XRPUSDT": "XRP-USD",
+}
+
+
+def to_interval(tf: str) -> str:
+    m = {"1m": "1m", "5m": "5m", "15m": "15m", "30m": "30m", "1h": "60m", "1d": "1d"}
+    return m.get(tf, "1m")
+
+
+def download_symbol(symbol: str, timeframe: str, period: str, out_dir: Path):
+    yf_symbol = YF_MAP.get(symbol, symbol)
+    interval = to_interval(timeframe)
+    hist = yf.Ticker(yf_symbol).history(period=period, interval=interval, actions=False)
+    if hist.empty:
+        print(f"[WARN] no data for {symbol}")
+        return
+
+    df = hist[["Open", "High", "Low", "Close", "Volume"]].copy()
+    df.columns = ["open", "high", "low", "close", "volume"]
+    df.index = pd.to_datetime(df.index, utc=True)
+    df = df.sort_index().dropna()
+
+    out_path = out_dir / f"{symbol}_{timeframe}.parquet"
+    df.to_parquet(out_path)
+    print(f"[OK] wrote {out_path} rows={len(df)}")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Download crypto data to parquet")
+    p.add_argument("--symbols", nargs="+", default=DEFAULT_SYMBOLS)
+    p.add_argument("--timeframe", default="1m")
+    p.add_argument("--period", default="60d")
+    p.add_argument("--output-dir", default="data/raw/crypto")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for s in args.symbols:
+        try:
+            download_symbol(s, args.timeframe, args.period, out_dir)
+        except Exception as exc:
+            print(f"[WARN] {s}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_fx_dukascopy_parquet.py
+++ b/scripts/download_fx_dukascopy_parquet.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Download Dukascopy FX tick data and store monthly M1 parquet files."""
+
+import argparse
+import os
+import lzma
+import struct
+import requests
+import pandas as pd
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timedelta
+from pathlib import Path
+
+REQUEST_TIMEOUT = 10
+
+
+def get_url(pair, year, month_zero, day, hour):
+    return (
+        f"https://datafeed.dukascopy.com/datafeed/"
+        f"{pair}/{year}/{month_zero:02d}/{day:02d}/{hour:02d}h_ticks.bi5"
+    )
+
+
+def download_hour(pair, year, month_zero, day, hour):
+    url = get_url(pair, year, month_zero, day, hour)
+    try:
+        r = requests.get(url, timeout=REQUEST_TIMEOUT)
+        if r.status_code != 200:
+            return None
+
+        decompressed = lzma.decompress(r.content)
+
+        rows = []
+        for i in range(0, len(decompressed), 20):
+            chunk = decompressed[i : i + 20]
+            if len(chunk) < 20:
+                continue
+            ms, bid, ask, bid_vol, ask_vol = struct.unpack(">I I I f f", chunk)
+            rows.append([ms, bid / 100000, ask / 100000, bid_vol, ask_vol])
+
+        if not rows:
+            return None
+
+        df = pd.DataFrame(rows, columns=["ms", "bid", "ask", "bid_vol", "ask_vol"])
+        base_time = datetime(year, month_zero + 1, day, hour)
+        df["datetime"] = base_time + pd.to_timedelta(df["ms"], unit="ms")
+        df = df.set_index("datetime")
+        return df
+    except Exception:
+        return None
+
+
+def process_month(pair, year, month_zero, out_dir: Path, max_workers: int):
+    out_path = out_dir / f"{pair}_M1_{year}_{month_zero+1:02d}.parquet"
+    if out_path.exists():
+        print(f"Skipping {pair} {year}-{month_zero+1:02d} (exists)")
+        return
+
+    print(f"Processing {pair} {year}-{month_zero+1:02d}")
+    start = datetime(year, month_zero + 1, 1)
+    end = (start + pd.offsets.MonthEnd(1)).to_pydatetime() + timedelta(days=1)
+
+    all_frames = []
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = []
+        current = start
+        while current < end:
+            for hour in range(24):
+                futures.append(
+                    executor.submit(
+                        download_hour,
+                        pair,
+                        current.year,
+                        current.month - 1,
+                        current.day,
+                        hour,
+                    )
+                )
+            current += timedelta(days=1)
+
+        for f in as_completed(futures):
+            df = f.result()
+            if df is not None:
+                all_frames.append(df)
+
+    if not all_frames:
+        print(f"  No data for {pair} {year}-{month_zero+1:02d}")
+        return
+
+    ticks = pd.concat(all_frames).sort_index()
+    m1 = ticks["bid"].resample("1min").ohlc()
+    m1["volume"] = ticks["bid_vol"].resample("1min").sum()
+    m1 = m1.dropna()
+    m1.to_parquet(out_path)
+    print(f"  Saved {out_path}")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Download Dukascopy FX data to parquet")
+    p.add_argument("--pairs", nargs="+", default=["EURUSD", "USDJPY", "GBPUSD", "USDCHF", "AUDUSD"])
+    p.add_argument("--start-year", type=int, default=2016)
+    p.add_argument("--end-year", type=int, default=2025)
+    p.add_argument("--output-dir", default="data/raw/fx")
+    p.add_argument("--max-workers", type=int, default=10)
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for pair in args.pairs:
+        print(f"\n===== STARTING {pair} =====")
+        for year in range(args.start_year, args.end_year + 1):
+            for month_zero in range(12):
+                process_month(pair, year, month_zero, out_dir, args.max_workers)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/production_backtest.py
+++ b/scripts/production_backtest.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Strict OOS backtest using local parquet (preferred) or API data."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+import joblib
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _load_market_module():
+    module_path = ROOT / "app" / "market_data.py"
+    spec = importlib.util.spec_from_file_location("neko_market_data", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load market_data module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MARKET = _load_market_module()
+
+
+@dataclass
+class BTConfig:
+    timeframe: str
+    data_mode: str
+    limit: int
+    horizon: int
+    threshold: float | None
+    spread_bps: float
+    slippage_bps: float
+    fee_bps: float
+    min_rows_per_symbol: int
+
+
+def _ensure_ohlcv(df: pd.DataFrame) -> pd.DataFrame:
+    req = ["open", "high", "low", "close", "volume"]
+    if not set(req).issubset(df.columns):
+        raise ValueError("OHLCV columns missing")
+    out = df[req].copy()
+    out.index = pd.to_datetime(out.index, utc=True, errors="coerce")
+    out = out.dropna()
+    out = out[~out.index.duplicated(keep="last")].sort_index()
+    return out
+
+
+def load_local_parquet(symbol: str, timeframe: str) -> pd.DataFrame | None:
+    fx_dir = ROOT / "data" / "raw" / "fx"
+    crypto_dir = ROOT / "data" / "raw" / "crypto"
+
+    if symbol.endswith("USDT"):
+        f = crypto_dir / f"{symbol}_{timeframe}.parquet"
+        return pd.read_parquet(f) if f.exists() else None
+
+    files = sorted(fx_dir.glob(f"{symbol}_M1_*.parquet"))
+    if not files:
+        return None
+    return pd.concat([pd.read_parquet(fp) for fp in files]).sort_index()
+
+
+def _provider_attempts(symbol: str, timeframe: str, limit: int) -> Iterable[Tuple[str, Any]]:
+    yield "yfinance", lambda: MARKET.fetch_yfinance(symbol, timeframe, limit)
+    yield "twelvedata", lambda: MARKET.fetch_twelvedata(symbol, timeframe, limit)
+    yield "alphavantage", lambda: MARKET.fetch_alphavantage(symbol, timeframe, limit)
+
+
+def fetch_real_data(symbol: str, timeframe: str, limit: int, min_rows: int, data_mode: str) -> Tuple[pd.DataFrame, str]:
+    errs: List[str] = []
+
+    local_df = load_local_parquet(symbol, timeframe)
+    if local_df is not None:
+        try:
+            df = _ensure_ohlcv(local_df)
+            if len(df) >= min_rows and (df["close"] > 0).all():
+                return df.tail(limit), "local_parquet"
+            raise ValueError(f"quality fail rows={len(df)}")
+        except Exception as exc:  # noqa: BLE001
+            errs.append(f"local_parquet:{exc}")
+
+    if data_mode == "parquet-only":
+        raise RuntimeError(f"{symbol}: {' | '.join(errs) if errs else 'missing parquet'}")
+
+    for provider, fn in _provider_attempts(symbol, timeframe, limit):
+        try:
+            df = _ensure_ohlcv(fn())
+            if len(df) < min_rows:
+                raise ValueError(f"too few rows ({len(df)}<{min_rows})")
+            if (df["close"] <= 0).any():
+                raise ValueError("non-positive close")
+            return df, provider
+        except Exception as exc:  # noqa: BLE001
+            errs.append(f"{provider}:{exc}")
+
+    raise RuntimeError(f"{symbol}: data fetch failed ({' | '.join(errs)})")
+
+
+def _rsi(close: pd.Series, period: int = 14) -> pd.Series:
+    delta = close.diff()
+    up = delta.clip(lower=0)
+    down = -delta.clip(upper=0)
+    ru = up.ewm(alpha=1 / period, adjust=False).mean()
+    rd = down.ewm(alpha=1 / period, adjust=False).mean()
+    rs = ru / rd.replace(0, np.nan)
+    return 100 - (100 / (1 + rs))
+
+
+def _atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    prev_close = df["close"].shift(1)
+    tr = pd.concat([(df["high"] - df["low"]).abs(), (df["high"] - prev_close).abs(), (df["low"] - prev_close).abs()], axis=1).max(axis=1)
+    return tr.rolling(period).mean()
+
+
+def build_features(df: pd.DataFrame) -> pd.DataFrame:
+    x = df.copy()
+    x["ret_1"] = x["close"].pct_change(1)
+    x["ret_3"] = x["close"].pct_change(3)
+    x["ret_6"] = x["close"].pct_change(6)
+    x["ret_12"] = x["close"].pct_change(12)
+    x["log_ret_1"] = np.log(x["close"]).diff(1)
+    x["ema_8"] = x["close"].ewm(span=8, adjust=False).mean()
+    x["ema_21"] = x["close"].ewm(span=21, adjust=False).mean()
+    x["ema_55"] = x["close"].ewm(span=55, adjust=False).mean()
+    x["ema_spread_8_21"] = (x["ema_8"] - x["ema_21"]) / x["close"].replace(0, np.nan)
+    x["ema_spread_21_55"] = (x["ema_21"] - x["ema_55"]) / x["close"].replace(0, np.nan)
+    x["rsi_14"] = _rsi(x["close"], 14)
+    x["atr_14"] = _atr(x, 14)
+    x["atr_pct"] = x["atr_14"] / x["close"].replace(0, np.nan)
+    x["hl_range"] = (x["high"] - x["low"]) / x["close"].replace(0, np.nan)
+    x["vol_z20"] = (x["volume"] - x["volume"].rolling(20).mean()) / x["volume"].rolling(20).std().replace(0, np.nan)
+    x["mom_10"] = (x["close"] - x["close"].shift(10)) / x["close"].shift(10).replace(0, np.nan)
+    return x
+
+
+def assemble_panel(symbols: List[str], cfg: BTConfig) -> Tuple[pd.DataFrame, Dict[str, str]]:
+    rows: List[pd.DataFrame] = []
+    provenance: Dict[str, str] = {}
+    for sym in symbols:
+        try:
+            raw, provider = fetch_real_data(sym, cfg.timeframe, cfg.limit, cfg.min_rows_per_symbol, cfg.data_mode)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[WARN] {sym}: {exc}")
+            continue
+
+        f = build_features(raw)
+        f["target_return"] = (f["close"].shift(-cfg.horizon) / f["close"] - 1).clip(-0.05, 0.05)
+        f["target"] = (f["target_return"] > 0).astype(int)
+        f["symbol"] = sym
+        f = f.replace([np.inf, -np.inf], np.nan).dropna()
+        rows.append(f)
+        provenance[sym] = provider
+
+    if not rows:
+        raise RuntimeError("No real high-quality data available for backtest")
+
+    panel = pd.concat(rows).sort_index()
+    p = panel.pivot_table(index=panel.index, columns="symbol", values="ret_1")
+    panel["cross_ret_mean"] = p.mean(axis=1).reindex(panel.index).fillna(0.0).values
+    panel["cross_ret_std"] = p.std(axis=1).reindex(panel.index).fillna(0.0).values
+    panel = panel.replace([np.inf, -np.inf], np.nan).dropna(subset=["target", "target_return"])
+    return panel, provenance
+
+
+def max_drawdown(equity: np.ndarray) -> float:
+    peaks = np.maximum.accumulate(equity) if len(equity) else np.array([1.0])
+    dd = (equity - peaks) / np.maximum(peaks, 1e-9) if len(equity) else np.array([0.0])
+    return float(dd.min())
+
+
+def ann_factor(tf: str) -> float:
+    return float({"1m": 365 * 24 * 60, "5m": 365 * 24 * 12, "15m": 365 * 24 * 4, "30m": 365 * 24 * 2, "1h": 365 * 24, "4h": 365 * 6, "1d": 365}.get(tf, 365 * 24 * 12))
+
+
+def run_backtest(bundle_path: Path, cfg: BTConfig) -> Dict[str, Any]:
+    bundle = joblib.load(bundle_path)
+    model = bundle["model"]
+    symbols = bundle["symbols"]
+    feats = bundle["feature_columns"]
+    threshold = cfg.threshold if cfg.threshold is not None else float(bundle.get("best_threshold", 0.55))
+
+    panel, provenance = assemble_panel(symbols, cfg)
+    ts = np.array(sorted(panel.index.unique()))
+    oos = panel[panel.index.map(lambda x: x in set(ts[int(len(ts) * 0.7):]))].copy()
+    if oos.empty:
+        raise RuntimeError("No OOS rows available")
+
+    X = oos[feats]
+    ret = np.clip(oos["target_return"].to_numpy(), -0.20, 0.20)
+    proba = model.predict_proba(X)[:, 1]
+    signal = (proba >= threshold).astype(int)
+
+    costs = (cfg.spread_bps + cfg.slippage_bps + cfg.fee_bps) / 10000.0
+    strat_ret = np.where(signal == 1, ret - costs, 0.0)
+    strat_ret = np.clip(strat_ret, -0.20, 0.20)
+
+    equity = np.cumprod(1 + strat_ret)
+    market = np.cumprod(1 + ret)
+    trades = int(np.sum(signal == 1))
+    wins = int(np.sum(strat_ret > 0))
+    sharpe = float((np.mean(strat_ret) / (np.std(strat_ret) + 1e-12)) * math.sqrt(ann_factor(cfg.timeframe)))
+
+    result: Dict[str, Any] = {
+        "model_name": bundle.get("best_model_name"),
+        "threshold": threshold,
+        "rows_oos": int(len(oos)),
+        "trades": trades,
+        "win_rate": float(wins / trades) if trades else 0.0,
+        "avg_trade_return": float(np.mean(strat_ret[signal == 1])) if trades else 0.0,
+        "total_return": float(equity[-1] - 1) if len(equity) else 0.0,
+        "market_return": float(market[-1] - 1) if len(market) else 0.0,
+        "max_drawdown": max_drawdown(equity),
+        "sharpe": sharpe,
+        "costs_total_bps": cfg.spread_bps + cfg.slippage_bps + cfg.fee_bps,
+        "symbols": symbols,
+        "provenance": provenance,
+    }
+
+    by_symbol: Dict[str, Dict[str, float]] = {}
+    for sym, sdf in oos.groupby("symbol"):
+        xs = sdf[feats]
+        rs = np.clip(sdf["target_return"].to_numpy(), -0.20, 0.20)
+        ps = model.predict_proba(xs)[:, 1]
+        sg = (ps >= threshold).astype(int)
+        sr = np.clip(np.where(sg == 1, rs - costs, 0.0), -0.20, 0.20)
+        eq = np.cumprod(1 + sr)
+        by_symbol[sym] = {
+            "rows": float(len(sdf)),
+            "trades": float(np.sum(sg == 1)),
+            "return": float(eq[-1] - 1) if len(eq) else 0.0,
+            "win_rate": float(np.mean(sr[sg == 1] > 0)) if np.sum(sg == 1) else 0.0,
+        }
+
+    result["by_symbol"] = by_symbol
+    return result
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Strict production OOS backtest")
+    p.add_argument("--bundle", default="models/production/best_production_bundle.joblib")
+    p.add_argument("--timeframe", default="1m")
+    p.add_argument("--data-mode", choices=["parquet-only", "parquet-or-api"], default="parquet-only")
+    p.add_argument("--limit", type=int, default=10000)
+    p.add_argument("--horizon", type=int, default=3)
+    p.add_argument("--threshold", type=float, default=None)
+    p.add_argument("--spread-bps", type=float, default=2.0)
+    p.add_argument("--slippage-bps", type=float, default=1.0)
+    p.add_argument("--fee-bps", type=float, default=0.5)
+    p.add_argument("--min-rows", type=int, default=900)
+    p.add_argument("--output", default="models/production/latest_backtest.json")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    cfg = BTConfig(
+        timeframe=args.timeframe,
+        data_mode=args.data_mode,
+        limit=args.limit,
+        horizon=args.horizon,
+        threshold=args.threshold,
+        spread_bps=args.spread_bps,
+        slippage_bps=args.slippage_bps,
+        fee_bps=args.fee_bps,
+        min_rows_per_symbol=args.min_rows,
+    )
+
+    result = run_backtest(Path(args.bundle), cfg)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2))
+    print(json.dumps(result, indent=2))
+    print(f"[OK] saved report: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/production_train.py
+++ b/scripts/production_train.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Institutional-style training pipeline with strict data-quality gates."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.base import clone
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from xgboost import XGBClassifier
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from config import CRYPTO_ASSETS, FOREX_MAJORS
+
+
+def _load_market_module():
+    module_path = ROOT / "app" / "market_data.py"
+    spec = importlib.util.spec_from_file_location("neko_market_data", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load market_data module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MARKET = _load_market_module()
+MODEL_DIR = ROOT / "models" / "production"
+
+
+@dataclass
+class TrainConfig:
+    timeframe: str
+    data_mode: str
+    limit: int
+    horizon: int
+    min_rows_per_symbol: int
+    min_symbols: int
+    n_splits: int
+    embargo: int
+    train_fraction: float
+    random_state: int
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ensure_ohlcv(df: pd.DataFrame) -> pd.DataFrame:
+    required = ["open", "high", "low", "close", "volume"]
+    if not set(required).issubset(df.columns):
+        raise ValueError(f"Missing OHLCV columns, got: {list(df.columns)}")
+    out = df[required].copy()
+    out.index = pd.to_datetime(out.index, utc=True, errors="coerce")
+    out = out.dropna()
+    out = out[~out.index.duplicated(keep="last")].sort_index()
+    return out
+
+
+def _candle_quality_checks(df: pd.DataFrame, symbol: str, min_rows: int) -> None:
+    if len(df) < min_rows:
+        raise ValueError(f"{symbol}: insufficient rows ({len(df)} < {min_rows})")
+    if (df["close"] <= 0).any() or (df[["open", "high", "low"]] <= 0).any().any():
+        raise ValueError(f"{symbol}: non-positive prices detected")
+    if (df["high"] < df["low"]).any():
+        raise ValueError(f"{symbol}: high<low anomaly")
+
+
+def load_local_parquet(symbol: str, timeframe: str) -> pd.DataFrame | None:
+    fx_dir = ROOT / "data" / "raw" / "fx"
+    crypto_dir = ROOT / "data" / "raw" / "crypto"
+
+    if symbol.endswith("USDT"):
+        f = crypto_dir / f"{symbol}_{timeframe}.parquet"
+        return pd.read_parquet(f) if f.exists() else None
+
+    files = sorted(fx_dir.glob(f"{symbol}_M1_*.parquet"))
+    if not files:
+        return None
+    return pd.concat([pd.read_parquet(fp) for fp in files]).sort_index()
+
+
+def _provider_attempts(symbol: str, timeframe: str, limit: int) -> Iterable[Tuple[str, Any]]:
+    yield "yfinance", lambda: MARKET.fetch_yfinance(symbol, timeframe, limit)
+    yield "twelvedata", lambda: MARKET.fetch_twelvedata(symbol, timeframe, limit)
+    yield "alphavantage", lambda: MARKET.fetch_alphavantage(symbol, timeframe, limit)
+
+
+def fetch_real_data(symbol: str, timeframe: str, limit: int, min_rows: int, data_mode: str) -> Tuple[pd.DataFrame, str]:
+    errors: List[str] = []
+
+    local_df = load_local_parquet(symbol, timeframe)
+    if local_df is not None:
+        try:
+            df = _ensure_ohlcv(local_df)
+            _candle_quality_checks(df, symbol, min_rows)
+            return df.tail(limit), "local_parquet"
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"local_parquet: {exc}")
+
+    if data_mode == "parquet-only":
+        msg = " | ".join(errors) if errors else "no local parquet file"
+        raise RuntimeError(f"{symbol}: {msg}")
+
+    for provider, fn in _provider_attempts(symbol, timeframe, limit):
+        try:
+            df = _ensure_ohlcv(fn())
+            _candle_quality_checks(df, symbol, min_rows)
+            return df, provider
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{provider}: {exc}")
+
+    raise RuntimeError(f"{symbol}: all providers failed -> {' | '.join(errors)}")
+
+
+def _rsi(close: pd.Series, period: int = 14) -> pd.Series:
+    delta = close.diff()
+    up = delta.clip(lower=0)
+    down = -delta.clip(upper=0)
+    ru = up.ewm(alpha=1 / period, adjust=False).mean()
+    rd = down.ewm(alpha=1 / period, adjust=False).mean()
+    rs = ru / rd.replace(0, np.nan)
+    return 100 - (100 / (1 + rs))
+
+
+def _atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    prev_close = df["close"].shift(1)
+    tr = pd.concat(
+        [(df["high"] - df["low"]).abs(), (df["high"] - prev_close).abs(), (df["low"] - prev_close).abs()],
+        axis=1,
+    ).max(axis=1)
+    return tr.rolling(period).mean()
+
+
+def build_features(df: pd.DataFrame) -> pd.DataFrame:
+    x = df.copy()
+    x["ret_1"] = x["close"].pct_change(1)
+    x["ret_3"] = x["close"].pct_change(3)
+    x["ret_6"] = x["close"].pct_change(6)
+    x["ret_12"] = x["close"].pct_change(12)
+    x["log_ret_1"] = np.log(x["close"]).diff(1)
+    x["ema_8"] = x["close"].ewm(span=8, adjust=False).mean()
+    x["ema_21"] = x["close"].ewm(span=21, adjust=False).mean()
+    x["ema_55"] = x["close"].ewm(span=55, adjust=False).mean()
+    x["ema_spread_8_21"] = (x["ema_8"] - x["ema_21"]) / x["close"].replace(0, np.nan)
+    x["ema_spread_21_55"] = (x["ema_21"] - x["ema_55"]) / x["close"].replace(0, np.nan)
+    x["rsi_14"] = _rsi(x["close"], 14)
+    x["atr_14"] = _atr(x, 14)
+    x["atr_pct"] = x["atr_14"] / x["close"].replace(0, np.nan)
+    x["hl_range"] = (x["high"] - x["low"]) / x["close"].replace(0, np.nan)
+    x["vol_z20"] = (x["volume"] - x["volume"].rolling(20).mean()) / x["volume"].rolling(20).std().replace(0, np.nan)
+    x["mom_10"] = (x["close"] - x["close"].shift(10)) / x["close"].shift(10).replace(0, np.nan)
+    return x
+
+
+def assemble_panel(cfg: TrainConfig, symbols: List[str]) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+    rows: List[pd.DataFrame] = []
+    provenance: Dict[str, str] = {}
+    coverage: Dict[str, int] = {}
+
+    for sym in symbols:
+        try:
+            raw, provider = fetch_real_data(sym, cfg.timeframe, cfg.limit, cfg.min_rows_per_symbol, cfg.data_mode)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[WARN] {sym}: {exc}")
+            continue
+
+        feat = build_features(raw)
+        feat["target_return"] = (feat["close"].shift(-cfg.horizon) / feat["close"] - 1).clip(-0.05, 0.05)
+        feat["target"] = (feat["target_return"] > 0).astype(int)
+        feat["symbol"] = sym
+        feat = feat.replace([np.inf, -np.inf], np.nan).dropna()
+        if len(feat) < cfg.min_rows_per_symbol // 2:
+            continue
+
+        rows.append(feat)
+        provenance[sym] = provider
+        coverage[sym] = int(len(feat))
+
+    if len(rows) < cfg.min_symbols:
+        raise RuntimeError(f"Insufficient high-quality symbols ({len(rows)} < {cfg.min_symbols})")
+
+    panel = pd.concat(rows).sort_index()
+    p = panel.pivot_table(index=panel.index, columns="symbol", values="ret_1")
+    panel["cross_ret_mean"] = p.mean(axis=1).reindex(panel.index).fillna(0.0).values
+    panel["cross_ret_std"] = p.std(axis=1).reindex(panel.index).fillna(0.0).values
+    panel = panel.replace([np.inf, -np.inf], np.nan).dropna(subset=["target", "target_return"])
+
+    return panel, {"provenance": provenance, "coverage_rows": coverage, "rows_total": int(len(panel)), "symbols_used": sorted(coverage)}
+
+
+def feature_columns(df: pd.DataFrame) -> List[str]:
+    return [c for c in df.columns if c not in {"target", "target_return", "symbol"}]
+
+
+def walk_forward_splits(index: pd.DatetimeIndex, n_splits: int, train_fraction: float, embargo: int):
+    ts = np.array(sorted(index.unique()))
+    n = len(ts)
+    if n < 120:
+        raise RuntimeError("Too few unique timestamps")
+    train_size = max(int(n * train_fraction), 80)
+    test_size = max((n - train_size) // max(n_splits, 1), 20)
+    for i in range(n_splits):
+        tr_end = train_size + i * test_size
+        te_start = min(tr_end + embargo, n - 1)
+        te_end = min(te_start + test_size, n)
+        if te_end - te_start < 10:
+            continue
+        yield set(ts[:tr_end]), set(ts[te_start:te_end])
+
+
+def build_candidates(seed: int) -> Dict[str, Pipeline]:
+    return {
+        "xgb": Pipeline([("imp", SimpleImputer(strategy="median")), ("m", XGBClassifier(n_estimators=700, max_depth=6, learning_rate=0.03, subsample=0.9, colsample_bytree=0.85, random_state=seed, n_jobs=-1, eval_metric="logloss"))]),
+        "rf": Pipeline([("imp", SimpleImputer(strategy="median")), ("m", RandomForestClassifier(n_estimators=700, max_depth=10, min_samples_leaf=3, class_weight="balanced_subsample", random_state=seed, n_jobs=-1))]),
+        "logreg": Pipeline([("imp", SimpleImputer(strategy="median")), ("sc", StandardScaler()), ("m", LogisticRegression(C=0.7, class_weight="balanced", random_state=seed, max_iter=500, n_jobs=-1))]),
+    }
+
+
+def trading_objective(y_true: np.ndarray, proba: np.ndarray, threshold: float, cost_bps: float) -> Dict[str, float]:
+    pred = (proba >= threshold).astype(int)
+    costs = cost_bps / 10000.0
+    pnl = np.where(pred == 1, np.where(y_true == 1, 1.0 - costs, -1.0 - costs), 0.0)
+    auc = float(roc_auc_score(y_true, proba)) if len(np.unique(y_true)) > 1 else 0.5
+    sharpe = float(np.mean(pnl) / (np.std(pnl) + 1e-9))
+    trade_count = int(np.sum(pred == 1))
+    win_rate = float(np.mean(pnl[pred == 1] > 0)) if trade_count else 0.0
+    score = 0.55 * sharpe + 0.35 * auc + 0.10 * (win_rate - 0.5)
+    return {"score": score, "auc": auc, "sharpe": sharpe, "trade_count": float(trade_count), "win_rate": win_rate}
+
+
+def threshold_search(y_true: np.ndarray, proba: np.ndarray, cost_bps: float) -> Tuple[float, Dict[str, float]]:
+    best_t, best_m = 0.55, None
+    for t in np.arange(0.52, 0.71, 0.01):
+        m = trading_objective(y_true, proba, float(t), cost_bps)
+        if best_m is None or m["score"] > best_m["score"]:
+            best_t, best_m = float(t), m
+    return best_t, best_m
+
+
+def train(cfg: TrainConfig, symbols: List[str], cost_bps: float) -> Path:
+    panel, meta = assemble_panel(cfg, symbols)
+    feats = feature_columns(panel)
+    candidates = build_candidates(cfg.random_state)
+    folds = {k: [] for k in candidates}
+
+    for fold, (tr_ts, te_ts) in enumerate(walk_forward_splits(panel.index, cfg.n_splits, cfg.train_fraction, cfg.embargo), start=1):
+        tr = panel[panel.index.map(lambda x: x in tr_ts)]
+        te = panel[panel.index.map(lambda x: x in te_ts)]
+        x_tr, y_tr = tr[feats], tr["target"].astype(int).to_numpy()
+        x_te, y_te = te[feats], te["target"].astype(int).to_numpy()
+
+        for name, model in candidates.items():
+            m = clone(model)
+            m.fit(x_tr, y_tr)
+            p = m.predict_proba(x_te)[:, 1]
+            thr, metrics = threshold_search(y_te, p, cost_bps)
+            metrics["threshold"] = thr
+            folds[name].append(metrics)
+            print(f"[fold={fold}] {name}: score={metrics['score']:.4f} auc={metrics['auc']:.4f} thr={thr:.2f}")
+
+    summary = {name: {k: float(np.mean([m[k] for m in vals])) for k in vals[0]} for name, vals in folds.items() if vals}
+    if not summary:
+        raise RuntimeError("No valid folds completed")
+
+    best_name = max(summary, key=lambda n: summary[n]["score"])
+    best_threshold = summary[best_name]["threshold"]
+    best_model = clone(candidates[best_name])
+    best_model.fit(panel[feats], panel["target"].astype(int).to_numpy())
+
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    out = MODEL_DIR / "best_production_bundle.joblib"
+    bundle = {
+        "created_at_utc": utc_now(),
+        "config": cfg.__dict__,
+        "symbols": meta["symbols_used"],
+        "feature_columns": feats,
+        "provenance": meta["provenance"],
+        "coverage_rows": meta["coverage_rows"],
+        "rows_total": meta["rows_total"],
+        "selection_cost_bps": cost_bps,
+        "best_model_name": best_name,
+        "best_threshold": best_threshold,
+        "cv_summary": summary,
+        "model": best_model,
+    }
+    joblib.dump(bundle, out)
+    (MODEL_DIR / "best_production_bundle.meta.json").write_text(json.dumps({k: v for k, v in bundle.items() if k != "model"}, indent=2))
+    print(f"[OK] bundle: {out}")
+    return out
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Strict production training pipeline")
+    p.add_argument("--timeframe", default="1m")
+    p.add_argument("--data-mode", choices=["parquet-only", "parquet-or-api"], default="parquet-only")
+    p.add_argument("--limit", type=int, default=10000)
+    p.add_argument("--horizon", type=int, default=3)
+    p.add_argument("--min-rows", type=int, default=1200)
+    p.add_argument("--min-symbols", type=int, default=8)
+    p.add_argument("--splits", type=int, default=5)
+    p.add_argument("--embargo", type=int, default=2)
+    p.add_argument("--train-fraction", type=float, default=0.7)
+    p.add_argument("--cost-bps", type=float, default=3.5)
+    p.add_argument("--seed", type=int, default=42)
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    cfg = TrainConfig(
+        timeframe=args.timeframe,
+        data_mode=args.data_mode,
+        limit=args.limit,
+        horizon=args.horizon,
+        min_rows_per_symbol=args.min_rows,
+        min_symbols=args.min_symbols,
+        n_splits=args.splits,
+        embargo=args.embargo,
+        train_fraction=args.train_fraction,
+        random_state=args.seed,
+    )
+    train(cfg, FOREX_MAJORS + CRYPTO_ASSETS, cost_bps=args.cost_bps)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a parquet-first data ingestion path for both FX tick data and crypto OHLCV to enable reproducible model training and backtesting. 
- Introduce an institutional-style, strict training pipeline that enforces data-quality gates, walk-forward CV and model/threshold selection for production deployments. 
- Add a strict out-of-sample backtester that prefers local parquet data and simulates cost-aware performance for saved model bundles.

### Description

- Add `scripts/download_fx_dukascopy_parquet.py` which fetches Dukascopy tick files, decompresses `.bi5` hourly files, aggregates to 1m OHLCV and writes monthly parquet files. 
- Add `scripts/download_crypto_parquet.py` which downloads crypto OHLCV via `yfinance`, normalizes columns and writes symbol/timeframe parquet files. 
- Add `scripts/production_train.py` implementing a parquet-first training pipeline with strict quality checks, feature engineering, walk-forward splits, candidate models (`XGB`, `RF`, `LogReg`), threshold search and bundle serialization to `models/production/best_production_bundle.joblib`. 
- Add `scripts/production_backtest.py` which loads a saved bundle, assembles a feature panel from parquet (or API providers if allowed), runs strict OOS simulation with configurable costs and writes a JSON report to `models/production/latest_backtest.json`. 
- Update `README.md` to document the new parquet-first workflow, example commands for `production_train.py` and `production_backtest.py`, and the new download scripts.

### Testing

- No automated tests were added or executed as part of this change. 
- The change is limited to new scripts and documentation, so adding CI/unit tests is recommended in follow-ups to validate data parsing, feature engineering and end-to-end pipeline behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a45b22fe208325832b0f19c923cae6)