### PR TITLE
Add detailed trade event logging to CSV and richer Telegram daily summary

### DIFF
--- a/app/trade_logger.py
+++ b/app/trade_logger.py
@@ -1,49 +1,201 @@
-# app/trade_logger.py
-
 import csv
+from collections import Counter
+from datetime import datetime, timezone
 from pathlib import Path
-from datetime import datetime
+from typing import Optional
 
-# will live next to this file
-LOG_FILE = Path(__file__).parent / "trades.csv"
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+LOG_FILE = PROJECT_ROOT / "trade_activity.csv"
+
 HEADERS = [
-    "timestamp",
+    "timestamp_utc",
     "symbol",
     "signal",
+    "status",
     "volume",
     "entry_price",
     "exit_price",
     "profit",
     "win",
+    "model_name",
+    "indicator_used",
+    "indicator_reason",
+    "strategy_explanation",
+    "sl_price",
+    "tp1_price",
+    "tp2_price",
+    "tp3_price",
+    "sl_calculation",
+    "tp_calculation",
+    "news_sentiment",
+    "predicted_change_pct",
+    "confidence_pct",
+    "failure_reason",
+    "notes",
 ]
+
 
 def _ensure_file():
     if not LOG_FILE.exists():
-        with open(LOG_FILE, "w", newline="") as f:
-            writer = csv.writer(f)
-            writer.writerow(HEADERS)
+        with open(LOG_FILE, "w", newline="", encoding="utf-8") as f:
+            csv.writer(f).writerow(HEADERS)
 
-def log_trade(
+
+def log_trade_event(
+    *,
     symbol: str,
     signal: str,
-    volume: float,
-    entry_price: float,
-    exit_price: float,
-    profit: float,
-    win: bool
+    status: str,
+    volume: Optional[float] = None,
+    entry_price: Optional[float] = None,
+    exit_price: Optional[float] = None,
+    profit: Optional[float] = None,
+    win: Optional[bool] = None,
+    model_name: str = "",
+    indicator_used: str = "",
+    indicator_reason: str = "",
+    strategy_explanation: str = "",
+    sl_price: Optional[float] = None,
+    tp1_price: Optional[float] = None,
+    tp2_price: Optional[float] = None,
+    tp3_price: Optional[float] = None,
+    sl_calculation: str = "",
+    tp_calculation: str = "",
+    news_sentiment: Optional[float] = None,
+    predicted_change_pct: Optional[float] = None,
+    confidence_pct: Optional[float] = None,
+    failure_reason: str = "",
+    notes: str = "",
 ):
-    """Append one trade’s details to trades.csv."""
+    """Append a rich trading lifecycle event to project-level CSV."""
     _ensure_file()
-    timestamp = datetime.utcnow().isoformat()
-    with open(LOG_FILE, "a", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow([
-            timestamp,
-            symbol,
-            signal,
-            volume,
-            entry_price,
-            exit_price,
-            profit,
-            int(win),
-        ])
+    row = [
+        datetime.now(timezone.utc).isoformat(),
+        symbol,
+        signal,
+        status,
+        "" if volume is None else volume,
+        "" if entry_price is None else entry_price,
+        "" if exit_price is None else exit_price,
+        "" if profit is None else profit,
+        "" if win is None else int(bool(win)),
+        model_name,
+        indicator_used,
+        indicator_reason,
+        strategy_explanation,
+        "" if sl_price is None else sl_price,
+        "" if tp1_price is None else tp1_price,
+        "" if tp2_price is None else tp2_price,
+        "" if tp3_price is None else tp3_price,
+        sl_calculation,
+        tp_calculation,
+        "" if news_sentiment is None else news_sentiment,
+        "" if predicted_change_pct is None else predicted_change_pct,
+        "" if confidence_pct is None else confidence_pct,
+        failure_reason,
+        notes,
+    ]
+
+    with open(LOG_FILE, "a", newline="", encoding="utf-8") as f:
+        csv.writer(f).writerow(row)
+
+
+def log_trade(symbol, signal, volume, entry_price, exit_price, profit, win):
+    """Backward-compatible minimal logger wrapper used by backtester."""
+    log_trade_event(
+        symbol=symbol,
+        signal=signal,
+        status="closed",
+        volume=volume,
+        entry_price=entry_price,
+        exit_price=exit_price,
+        profit=profit,
+        win=win,
+        notes="legacy log_trade call",
+    )
+
+
+def _safe_float(v):
+    try:
+        if v is None or v == "":
+            return None
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def build_daily_summary(target_date=None):
+    """Return metrics dict and Telegram-ready summary for given UTC date."""
+    _ensure_file()
+    if target_date is None:
+        target_date = datetime.now(timezone.utc).date()
+
+    rows = []
+    with open(LOG_FILE, "r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for r in reader:
+            ts = r.get("timestamp_utc", "")
+            try:
+                dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if dt.date() == target_date:
+                rows.append(r)
+
+    if not rows:
+        msg = f"📊 Daily Trading Summary ({target_date} UTC)\nNo signals/trades recorded today."
+        return {"trades": 0, "signals": 0, "message": msg}
+
+    signals = len(rows)
+    executed = [r for r in rows if r.get("status") in {"executed", "closed"}]
+    closed = [r for r in rows if r.get("status") == "closed"]
+    failed = [r for r in rows if r.get("status") == "failed"]
+
+    pnl_values = [_safe_float(r.get("profit")) for r in closed]
+    pnl_values = [p for p in pnl_values if p is not None]
+    total_pnl = sum(pnl_values) if pnl_values else 0.0
+
+    win_vals = [r.get("win") for r in closed if r.get("win") in {"0", "1", 0, 1}]
+    wins = sum(int(w) for w in win_vals)
+    losses = len(win_vals) - wins
+    win_rate = (wins / len(win_vals) * 100) if win_vals else 0.0
+
+    assets = [r.get("symbol") for r in rows if r.get("symbol")]
+    counter = Counter(assets)
+    top_asset = counter.most_common(1)[0][0] if counter else "N/A"
+
+    avg_conf = [_safe_float(r.get("confidence_pct")) for r in rows]
+    avg_conf = [x for x in avg_conf if x is not None]
+    avg_conf_v = sum(avg_conf) / len(avg_conf) if avg_conf else 0.0
+
+    avg_move = [_safe_float(r.get("predicted_change_pct")) for r in rows]
+    avg_move = [x for x in avg_move if x is not None]
+    avg_move_v = sum(avg_move) / len(avg_move) if avg_move else 0.0
+
+    msg = (
+        f"📊 Daily Trading Summary ({target_date} UTC)\n"
+        f"Signals Logged: {signals}\n"
+        f"Trades Executed: {len(executed)}\n"
+        f"Trades Closed: {len(closed)}\n"
+        f"Failed Trade Attempts: {len(failed)}\n"
+        f"Total PnL: {total_pnl:.5f}\n"
+        f"Wins/Losses: {wins}/{losses} (WR {win_rate:.1f}%)\n"
+        f"Most Traded Asset: {top_asset}\n"
+        f"Avg Confidence: {avg_conf_v:.2f}%\n"
+        f"Avg Predicted Change: {avg_move_v:.2f}%"
+    )
+
+    return {
+        "signals": signals,
+        "trades": len(executed),
+        "closed": len(closed),
+        "failed": len(failed),
+        "total_pnl": total_pnl,
+        "wins": wins,
+        "losses": losses,
+        "win_rate": win_rate,
+        "most_traded_asset": top_asset,
+        "avg_confidence_pct": avg_conf_v,
+        "avg_predicted_change_pct": avg_move_v,
+        "message": msg,
+    }

--- a/app/trading.py
+++ b/app/trading.py
@@ -12,6 +12,7 @@ from app.mt5_handler import initialize_mt5, shutdown_mt5, open_trade, close_trad
 from app.news import get_news_sentiment
 from app.telegram_bot import send_message, send_message_channel
 from app.state import increment_trade_count
+from app.trade_logger import log_trade_event
 from app.risk_manager import RiskManager
 from app.id_manager import IDManager
 
@@ -79,12 +80,30 @@ def trading_job():
             pc = pm["model"].predict(latest[features])[0]
             sig = "BUY" if pc > 0 else "SELL"
             conf = abs(pc)
+            model_name = f"fx_regime_models (regime={regime})"
+            indicator_used = "Rolling volatility regime + trained regime-specific model"
+            indicator_reason = (
+                "Regime chosen from rolling volatility percentile (200-bar std ranked over 500 bars), "
+                "then the matching model predicts direction for current market condition."
+            )
+            strategy_explanation = (
+                "If model output > 0, bias is BUY; otherwise SELL. Confidence is the absolute model output."
+            )
         else:
             model = BasicModel()
             out = model.predict(df, ns)
             sig = out.get("signal", "HOLD").upper()
             conf = out.get("confidence", 0.0)
             pc = out.get("predicted_change", 0.0)
+            model_name = "MomentumModel (fallback)"
+            indicator_used = "MA, RSI, ATR, ADX, Bollinger width, MACD, OBV, sentiment"
+            indicator_reason = (
+                "Fallback model combines trend, momentum, volatility, volume, and sentiment features "
+                "to infer near-term direction."
+            )
+            strategy_explanation = (
+                "Model selects BUY/SELL from class probabilities and outputs predicted change and confidence."
+            )
 
         sid = idm.next()
 
@@ -107,6 +126,56 @@ def trading_job():
         tp1_price = entry + TP_AMOUNT * pip if sig == "BUY" else entry - TP_AMOUNT * pip
         tp2_price = entry + 2 * TP_AMOUNT * pip if sig == "BUY" else entry - 2 * TP_AMOUNT * pip
         tp3_price = entry + 3 * TP_AMOUNT * pip if sig == "BUY" else entry - 3 * TP_AMOUNT * pip
+        sl_calculation = (
+            f"SL = entry {'-' if sig == 'BUY' else '+'} (SL_AMOUNT={SL_AMOUNT} * pip={pip})"
+        )
+        tp_calculation = (
+            f"TP1/2/3 = entry {'+' if sig == 'BUY' else '-'} (TP_AMOUNT={TP_AMOUNT} * pip={pip}) * [1,2,3]"
+        )
+
+        log_trade_event(
+            symbol=sym,
+            signal=sig,
+            status="signal_generated",
+            entry_price=entry,
+            model_name=model_name,
+            indicator_used=indicator_used,
+            indicator_reason=indicator_reason,
+            strategy_explanation=strategy_explanation,
+            sl_price=sl_price,
+            tp1_price=tp1_price,
+            tp2_price=tp2_price,
+            tp3_price=tp3_price,
+            sl_calculation=sl_calculation,
+            tp_calculation=tp_calculation,
+            news_sentiment=ns,
+            predicted_change_pct=pc * 100,
+            confidence_pct=conf * 100,
+            notes="Signal generated before order placement.",
+        )
+
+        if sig == "HOLD":
+            log_trade_event(
+                symbol=sym,
+                signal=sig,
+                status="failed",
+                entry_price=entry,
+                model_name=model_name,
+                indicator_used=indicator_used,
+                indicator_reason=indicator_reason,
+                strategy_explanation=strategy_explanation,
+                sl_price=sl_price,
+                tp1_price=tp1_price,
+                tp2_price=tp2_price,
+                tp3_price=tp3_price,
+                sl_calculation=sl_calculation,
+                tp_calculation=tp_calculation,
+                news_sentiment=ns,
+                predicted_change_pct=pc * 100,
+                confidence_pct=conf * 100,
+                failure_reason="Model returned HOLD signal; no order submitted.",
+            )
+            continue
 
         box = (
             f"┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n"
@@ -135,14 +204,87 @@ def trading_job():
         volume = rm.get_lot()
         res    = open_trade(mt5, sym, sig, volume)
         if not res or (hasattr(res, "retcode") and res.retcode != 0):
+            failure_reason = "open_trade returned no result. Check MT5 logs for exact broker failure."
+            if hasattr(res, "retcode"):
+                failure_reason = f"retcode={res.retcode} comment={getattr(res, 'comment', '')}".strip()
+            log_trade_event(
+                symbol=sym,
+                signal=sig,
+                status="failed",
+                volume=volume,
+                entry_price=entry,
+                model_name=model_name,
+                indicator_used=indicator_used,
+                indicator_reason=indicator_reason,
+                strategy_explanation=strategy_explanation,
+                sl_price=sl_price,
+                tp1_price=tp1_price,
+                tp2_price=tp2_price,
+                tp3_price=tp3_price,
+                sl_calculation=sl_calculation,
+                tp_calculation=tp_calculation,
+                news_sentiment=ns,
+                predicted_change_pct=pc * 100,
+                confidence_pct=conf * 100,
+                failure_reason=failure_reason,
+            )
             continue
         ticket = getattr(res, "order", None)
+
+        log_trade_event(
+            symbol=sym,
+            signal=sig,
+            status="executed",
+            volume=volume,
+            entry_price=entry,
+            model_name=model_name,
+            indicator_used=indicator_used,
+            indicator_reason=indicator_reason,
+            strategy_explanation=strategy_explanation,
+            sl_price=sl_price,
+            tp1_price=tp1_price,
+            tp2_price=tp2_price,
+            tp3_price=tp3_price,
+            sl_calculation=sl_calculation,
+            tp_calculation=tp_calculation,
+            news_sentiment=ns,
+            predicted_change_pct=pc * 100,
+            confidence_pct=conf * 100,
+            notes=f"Order accepted. ticket={ticket}",
+        )
 
         time.sleep(MOCK_TRADE_HOLD_SECONDS)
         close_trade(mt5, ticket, sym)
 
         profit = random.choice([TP_AMOUNT * pip, -SL_AMOUNT * pip])
         win = profit > 0
+        exit_price = entry + profit if sig == "BUY" else entry - profit
+
+        log_trade_event(
+            symbol=sym,
+            signal=sig,
+            status="closed",
+            volume=volume,
+            entry_price=entry,
+            exit_price=exit_price,
+            profit=profit,
+            win=win,
+            model_name=model_name,
+            indicator_used=indicator_used,
+            indicator_reason=indicator_reason,
+            strategy_explanation=strategy_explanation,
+            sl_price=sl_price,
+            tp1_price=tp1_price,
+            tp2_price=tp2_price,
+            tp3_price=tp3_price,
+            sl_calculation=sl_calculation,
+            tp_calculation=tp_calculation,
+            news_sentiment=ns,
+            predicted_change_pct=pc * 100,
+            confidence_pct=conf * 100,
+            notes=f"Closed ticket={ticket}",
+        )
+
         increment_trade_count(sym, win=win)
         rm.adjust(win)
         print(f"🏁 {sym} {'WIN' if win else 'LOSS'} ({profit:.5f})")

--- a/daily_summary.py
+++ b/daily_summary.py
@@ -1,23 +1,7 @@
-import pandas as pd
-from datetime import datetime
-from app.trade_logger import LOG_FILE
+from app.trade_logger import build_daily_summary
 from app.telegram_bot import send_message_channel
 
+
 def send_daily_summary():
-    df = pd.read_csv(LOG_FILE, parse_dates=["timestamp"])
-    today = datetime.utcnow().date()
-    today_df = df[df.timestamp.dt.date == today]
-    if today_df.empty:
-        msg = "📊 Daily Summary:\nNo trades executed today."
-    else:
-        wins = today_df.profit > 0
-        wr = wins.mean() * 100
-        avg_ret = (today_df.profit / (today_df.entry * today_df.volume)).mean() * 100
-        msg = (
-            f"📊 Daily Summary ({today} UTC)\n"
-            f"Trades: {len(today_df)}\n"
-            f"Win Rate: {wr:.1f}%\n"
-            f"Avg Return per Trade: {avg_ret:.2f}%\n"
-            f"Total P/L: {today_df.profit.sum():.5f}"
-        )
-    send_message_channel(msg)
+    summary = build_daily_summary()
+    send_message_channel(summary["message"])


### PR DESCRIPTION
### Motivation
- Provide end-of-day Telegram statistics (total PnL, trade counts, most-traded asset, win/loss, avg confidence, etc.) and full auditability of every predicted signal and trade lifecycle. 
- Persist rich signal/trade metadata (model, indicators used, full explanations, SL/TP formulas, failure reasons) to a single project CSV so analysis and debugging are simple. 
- Keep backward compatibility for existing tests/backtester that use `log_trade(...)` while enabling much more detailed event logging.

### Description
- Reworked `app/trade_logger.py` to create a project-root CSV `trade_activity.csv` and added `log_trade_event(...)` with fields such as `model_name`, `indicator_used`, `indicator_reason`, `strategy_explanation`, `sl_price`, `tp1_price..tp3_price`, `sl_calculation`, `tp_calculation`, `predicted_change_pct`, `confidence_pct`, `failure_reason`, and `notes`, plus a backward-compatible `log_trade(...)` wrapper. 
- Implemented `build_daily_summary(...)` in `app/trade_logger.py` that aggregates the CSV for a UTC date and returns metrics including signals, executed/closed/failed counts, `total_pnl`, wins/losses and win rate, `most_traded_asset`, average confidence and predicted change, plus a Telegram-ready `message`. 
- Updated `app/trading.py` to import and call `log_trade_event(...)` at key points: when a signal is generated (`signal_generated`), when signal is `HOLD` (logged as `failed` with reason), when `open_trade` fails (captures `retcode`/`comment` if available) as `failed`, when an order is accepted (`executed`), and when trade is closed (`closed`) including simulated PnL and exit price; model/indicator rationale and SL/TP calculation strings are logged for each event. 
- Replaced the old `daily_summary.py` implementation with a thin wrapper that calls `build_daily_summary()` and sends the returned `message` to the configured Telegram channel via `send_message_channel(...)`.

### Testing
- Syntax check: `python -m py_compile app/trade_logger.py app/trading.py daily_summary.py` completed successfully (no syntax errors). 
- Runtime smoke import: attempting to import and call `build_daily_summary()` in this environment failed due to a missing external dependency (`vaderSentiment`) pulled in by other package imports, which is unrelated to the new files themselves and prevents a full runtime check here. 
- No unit tests were added; logging changes preserve the existing `log_trade(...)` API for backward compatibility and the CSV layout is human-readable for further validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab314bd0688325a2cbeffb76e0f635)